### PR TITLE
골키퍼 이미지 로고에 사용된 이미지로 변경, Gallery랑 List 컴포넌트 해시태그 글자 왼쪽 정렬

### DIFF
--- a/src/web/components/Gallery.css
+++ b/src/web/components/Gallery.css
@@ -39,6 +39,7 @@
     margin-top: 5%;
     margin-left: 4%;
     font-weight: bold;
+    text-align: left;
 }
 
 .gallery-jobDetail{
@@ -80,8 +81,8 @@
     border-bottom-right-radius: 5px;
 }
 
-.keeper img{
-    width: 300px;
+.keeper>img{
+    width: 120px;
     margin-left: 7%;
 }
 
@@ -105,7 +106,7 @@
         margin-left: 86%;
     }
     .keeper img{
-        width: 200px;
+        width: 100px;
         margin-left: 5%;
     }
 }
@@ -130,7 +131,7 @@
         margin-left: 78%;
     }
     .keeper img{
-        width: 120px;
+        width: 70px;
         margin-left: 3%;
     }
 }

--- a/src/web/components/Gallery.js
+++ b/src/web/components/Gallery.js
@@ -1,7 +1,7 @@
 import './Gallery.css';
 import React from 'react';
 import HeartButton from './HeartButton';
-import goalkeeper from '../images/goalkeeper.png';
+import goalkeeper from '../images/logo1.png';
 
 const Gallery = ({response, token, status}) => { // 매개변수로 response를 받음
     

--- a/src/web/components/List.css
+++ b/src/web/components/List.css
@@ -77,6 +77,7 @@
     font-weight: bold;
     padding-bottom: 1%;
     padding-left: 7%;
+    text-align: left;
 }
 
 .list-jobDetail {

--- a/src/web/components/List.css
+++ b/src/web/components/List.css
@@ -59,7 +59,7 @@
     margin-top: 40%;
     margin-left: 25%;
     font-size: 90%;
-    background-color: red;
+    background-color: rgb(255, 68, 68);
     color: white;
     text-align: center;
     line-height: 35px;


### PR DESCRIPTION
### 개요
- 공고에 사용되는 골키퍼 이미지 변경
- Gallery, List 컴포넌트 해시태그 글자 왼쪽 정렬
### 변경사항
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
### 관련 지라 및 위키 링크
[KAKEULGAE-93](https://kaclga.atlassian.net/browse/KAKEULGAE-93)
### 리뷰어에게 하고 싶은 말
Gallery랑 List 컴포넌트 해시태그 부분 글자 정렬이 가운데로 배치되어 있었어서 css 수정했습니다.

[KAKEULGAE-93]: https://kaclga.atlassian.net/browse/KAKEULGAE-93?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ